### PR TITLE
Update requirements

### DIFF
--- a/pixel_decoder/resnet_back.py
+++ b/pixel_decoder/resnet_back.py
@@ -28,9 +28,9 @@ from keras import backend as K
 from keras.engine.topology import get_source_inputs
 from keras.utils import layer_utils
 from keras.utils.data_utils import get_file
-from keras.applications.imagenet_utils import decode_predictions
-from keras.applications.imagenet_utils import preprocess_input
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import decode_predictions
+from keras_applications.imagenet_utils import preprocess_input
+from keras_applications.imagenet_utils import _obtain_input_shape
 
 
 WEIGHTS_PATH = 'https://github.com/fchollet/deep-learning-models/releases/download/v0.2/resnet50_weights_tf_dim_ordering_tf_kernels.h5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython==0.26.1
 dask==0.15.3
-decorator==4.1.2
+decorator==4.3.0
 distributed==1.19.1
 docutils==0.14
 entrypoints==0.2.3
@@ -11,6 +11,7 @@ lxml==4.1.0
 Markdown==2.6.11
 MarkupSafe==1.0
 matplotlib==2.1.0
+opencv-python==3.4.3.18
 packaging==16.8
 pandas==0.20.3
 pyflakes==1.6.0
@@ -27,6 +28,7 @@ Shapely==1.6.4.post1
 simplegeneric==0.8.1
 singledispatch==3.4.0.3
 six==1.11.0
+tensorflow==1.10.0
 tornado==4.5.2
 tqdm==4.23.0
 traitlets==4.3.2


### PR DESCRIPTION
Updated requirements:
* upgrade `decorator` from version 4.1.2 to 4.3.0
* add `tensorflow` version 1.10.0
* add `opencv-python` version 3.4.3.18

Changes in file `pixel_decoder/resnet_back.py`  
`keras.applications.imagenet_utils` to `keras_applications.imagenet_utils` to match with Keras 2.2.2